### PR TITLE
Fix for loader.py failing with SQL0670N

### DIFF
--- a/2_loader/loader.py
+++ b/2_loader/loader.py
@@ -43,21 +43,28 @@ taskDetailFileName = "task_details_copy.json"
 
 # Set up preconditions. Set up the table space with proper page size.
 def createDBObjects(conn):
-  # Create a system temporary table space with a sufficient page size
+  # Drop the system temporary table space
   try:
     stmt = ibm_db.exec_immediate(conn, "drop tablespace {}".format(tempTsName))
-    stmt = ibm_db.exec_immediate(conn, "drop bufferpool {}".format(bp32kName))
   except:
-    pass
-  stmt = ibm_db.exec_immediate(conn, "create bufferpool {} pagesize 32K".format(bp32kName))
-  stmt = ibm_db.exec_immediate(conn, "create system temporary tablespace {} pagesize 32K bufferpool {}".format(tempTsName, bp32kName))
+     pass
 
   # Drop tables
-  print("Drop table space", monTSName)
   try:
+    print("Drop table space", monTSName)
     stmt = ibm_db.exec_immediate(conn,"drop tablespace {}".format(monTSName))
   except:
     pass
+
+  # Drop buffer pool
+  try:
+    stmt = ibm_db.exec_immediate(conn, "drop bufferpool {}".format(bp32kName))
+  except:
+    pass
+
+  # Create buffer pool and table spaces
+  stmt = ibm_db.exec_immediate(conn, "create bufferpool {} pagesize 32K".format(bp32kName))
+  stmt = ibm_db.exec_immediate(conn, "create system temporary tablespace {} pagesize 32K bufferpool {}".format(tempTsName, bp32kName))
   print("Create table space", monTSName)
   stmt = ibm_db.exec_immediate(conn,"create tablespace {} pagesize 32K bufferpool {}".format(monTSName, bp32kName))
 

--- a/2_loader/loader.py
+++ b/2_loader/loader.py
@@ -38,11 +38,20 @@ monTSName = "HISTMON"
 delExt = "_DELTA"
 schemaName = "IBMHIST"
 tempTsName = "MONTMP32K"
-tempBpName = "MONBP32K"
+bp32kName = "MONBP32K"
 taskDetailFileName = "task_details_copy.json"
 
 # Set up preconditions. Set up the table space with proper page size.
 def createDBObjects(conn):
+  # Create a system temporary table space with a sufficient page size
+  try:
+    stmt = ibm_db.exec_immediate(conn, "drop tablespace {}".format(tempTsName))
+    stmt = ibm_db.exec_immediate(conn, "drop bufferpool {}".format(bp32kName))
+  except:
+    pass
+  stmt = ibm_db.exec_immediate(conn, "create bufferpool {} pagesize 32K".format(bp32kName))
+  stmt = ibm_db.exec_immediate(conn, "create system temporary tablespace {} pagesize 32K bufferpool {}".format(tempTsName, bp32kName))
+
   # Drop tables
   print("Drop table space", monTSName)
   try:
@@ -50,16 +59,8 @@ def createDBObjects(conn):
   except:
     pass
   print("Create table space", monTSName)
-  stmt = ibm_db.exec_immediate(conn,"create tablespace {}".format(monTSName))
-  
-  # Create a system temporary table space with a sufficient page size
-  try:
-    stmt = ibm_db.exec_immediate(conn, "drop tablespace {}".format(tempTsName))
-    stmt = ibm_db.exec_immediate(conn, "drop bufferpool {}".format(tempBpName))
-  except:
-    pass
-  stmt = ibm_db.exec_immediate(conn, "create bufferpool {} pagesize 32K".format(tempBpName))
-  stmt = ibm_db.exec_immediate(conn, "create system temporary tablespace {} pagesize 32K bufferpool {}".format(tempTsName, tempBpName))
+  stmt = ibm_db.exec_immediate(conn,"create tablespace {} pagesize 32K bufferpool {}".format(monTSName, bp32kName))
+
   return 0
 
 def main():

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-Free the world!!!
-
 This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Free the world!!!
+
 This is free and unencumbered software released into the public domain.
 
 Anyone is free to copy, modify, publish, use, compile, sell, or


### PR DESCRIPTION
`loader.py` may fail with
```
Creating the data table: IBMHIST.MON_GET_DATABASE
Traceback (most recent call last):
  File "loader.py", line 204, in <module>
    main()
  File "loader.py", line 142, in main
    stmt = ibm_db.exec_immediate(conn, createTable)
Exception: [IBM][CLI Driver][DB2/LINUXX8664] SQL0670N  The statement failed because the row or column size of the resulting table would have exceeded the row or column size limit: "4005". Table space name: "HISTMON". Resulting row or column size: "4337".  SQLSTATE=54010 SQLCODE=-670
```
The problem is that we need a table space with a larger page size. Fixed by creating `HISTMON` as a 32K page size table space. Tested locally.