### PR TITLE
Do not calculate deltas for COLLECTION_TIME

### DIFF
--- a/2_loader/loader.py
+++ b/2_loader/loader.py
@@ -173,7 +173,7 @@ def main():
         while tuple != False:
           colName, colType = tuple[0], tuple[2]
           loadDeltaStmt = "{} {},".format(loadDeltaStmt, colName)
-          if colType in ["TIMESTAMP", "BIGINT"] and colName not in exemptionColList:
+          if colType in ["TIMESTAMP", "BIGINT"] and colName not in exemptionColList and colName != collectionTimeColName:
             if colType == "TIMESTAMP":
               alterColList.append(colName)
               colList="{} COALESCE(TIMESTAMPDIFF(2, current.{} - previous.{}), 0),".format(colList, colName, colName)


### PR DESCRIPTION
`COLLECTION_TIME` in delta tables should be a point of reference to match the original row in the source table. Currently, `COLLECTION_TIME` contains a time delta (in seconds) with respect to the previous row. This information is useless. For example:

```
db2 "select collection_time, member, avg(client_idle_wait_time) client_idle_wait_time, avg(total_rqst_time) total_rqst_time from ibmhist.mon_get_connection_delta where client_idle_wait_time <> 0 or total_rqst_time <> 0 group by collection_time, member order by collection_time"
COLLECTION_TIME      MEMBER CLIENT_IDLE_WAIT_TIME TOTAL_RQST_TIME
-------------------- ------ --------------------- --------------------
                 179      0                178426                    0
                 180      0                181941                    0
```
The fix is to exclude `COLLECTION_TIME` from the delta calculations. Test results:
```
db2 "select collection_time, member, avg(client_idle_wait_time) client_idle_wait_time, avg(total_rqst_time) total_rqst_time from ibmhist.mon_get_connection_delta where client_idle_wait_time <> 0 or total_rqst_time <> 0 group by collection_time, member order by collection_time"
COLLECTION_TIME            MEMBER CLIENT_IDLE_WAIT_TIME TOTAL_RQST_TIME
-------------------------- ------ --------------------- --------------------
2021-04-27-15.03.00.739867      0                176440                    0
2021-04-27-15.06.00.932213      0                176419                    0
```

