### PR TITLE
Load diffs

### DIFF
--- a/1_setup/setup.py
+++ b/1_setup/setup.py
@@ -329,6 +329,9 @@ def schedule_tasks(conn, database, in_coll_lvl, env):
     # insert tasks into IBMHIST.TAB_TASKS and schedule with Admin Task Scheduler
     for task in tasks:
 
+        if 'collection_name' not in task:
+            continue
+
         # get paramaters
         collection_name = task['collection_name']
         collection_freq = task['collection_freq']

--- a/1_setup/setup.py
+++ b/1_setup/setup.py
@@ -74,7 +74,7 @@ def setup_IBMHIST(conn, bldrtn_path):
 
     # build external functions
     print("        Building external functions ...")
-    subprocess.check_call("bldrtn.bat external", shell=True) if os.name == 'nt' else subprocess.check_call("bldrtn external", shell=True)
+    subprocess.check_call("bldrtn.bat external", shell=True) if os.name == 'nt' else subprocess.check_call("./bldrtn external", shell=True)
     exec_sql_file(conn, "external.sql")
 
     # register tables
@@ -152,14 +152,14 @@ def config_IBMHIST(conn, coll_path, arch_path, max_size, arch_cmd, arch_ext):
     print("    Setting COLL_PATH to '%s' ..." % (coll_path) )
     assert os.path.exists(coll_path), "Data collection path: %s does not exist" % (coll_path)
     stmt, ret_coll_path, retcode = ibm_db.callproc(conn, 'IBMHIST.PATH_READABLE_WRITABLE', (coll_path, 0))
-    assert retcode is 0 or retcode is None, "Data collection path: %s does not provide fenced external functions read/write access" % (coll_path)
+    assert retcode == 0 or retcode is None, "Data collection path: %s does not provide fenced external functions read/write access" % (coll_path)
     ibm_db.exec_immediate(conn, "INSERT INTO IBMHIST.TAB_CONFIG VALUES ( 'COLL_PATH', '%s', 'DIRECTORY PATH OF DATA COLLECTION') " % (coll_path) )
 
     # add data archival path configuration
     print("    Setting ARCH_PATH to '%s' ..." % (arch_path) )
     assert os.path.exists(arch_path), "Data archival path: %s does not exist" % (arch_path)
     stmt, ret_arch_path, retcode = ibm_db.callproc(conn, 'IBMHIST.PATH_READABLE_WRITABLE', (arch_path, 0))
-    assert retcode is 0 or retcode is None, "Data archival path: %s does not provide fenced external functions read/write access" % (arch_path)
+    assert retcode == 0 or retcode is None, "Data archival path: %s does not provide fenced external functions read/write access" % (arch_path)
     ibm_db.exec_immediate(conn, "INSERT INTO IBMHIST.TAB_CONFIG VALUES ( 'ARCH_PATH', '%s', 'DIRECTORY PATH OF DATA ARCHIVAL') " % (arch_path) )
 
     # add max size configuration

--- a/1_setup/task_details.json
+++ b/1_setup/task_details.json
@@ -1,22 +1,22 @@
 [
     {
-        "field_name": "AV_PREFETCH_WAIT_TIME",
+        "field_name": "@AV_PREFETCH_WAIT_TIME",
         "field_valid": "true",
         "field_type": "decimal(5,2)",
         "field_formula": "CASE WHEN PREFETCH_WAITS = 0 THEN 0 ELSE ( PREFETCH_WAIT_TIME / PREFETCH_WAIT_TIME ) end"
     },
     {
-        "field_name": "ACTIVE_LOG_RANGE",
+        "field_name": "@ACTIVE_LOG_RANGE",
         "field_valid": "false"
     },
     {
-        "field_name": "TOTAL_POOL_L_READS",
+        "field_name": "@TOTAL_POOL_L_READS",
         "field_valid": "true",
         "field_type": "bigint",
         "field_formula": "POOL_DATA_L_READS + POOL_INDEX_L_READS + POOL_TEMP_DATA_L_READS + POOL_TEMP_INDEX_L_READS + POOL_TEMP_XDA_L_READS + POOL_XDA_L_READS"
     },
     {
-        "field_name": "TOTAL_POOL_P_READS",
+        "field_name": "@TOTAL_POOL_P_READS",
         "field_valid": "true",
         "field_type": "bigint",
         "field_formula": "POOL_DATA_P_READS + POOL_INDEX_P_READS + POOL_TEMP_DATA_P_READS + POOL_TEMP_INDEX_P_READS + POOL_TEMP_XDA_P_READS + POOL_XDA_P_READS"
@@ -61,7 +61,7 @@
         "collection_freq": "*/3 * * * *",
         "collection_level": "1",
         "collection_condition": "",
-	"loader_additional_fields": "AV_PREFETCH_WAIT_TIME, TOTAL_POOL_L_READS, TOTAL_POOL_P_READS",
+	"loader_additional_fields": "@AV_PREFETCH_WAIT_TIME, @TOTAL_POOL_L_READS, @TOTAL_POOL_P_READS",
         "loader_join_columns": "APPLICATION_HANDLE, MEMBER",
         "loader_diff_exempt_columns": "APPLICATION_HANDLE, CLIENT_PID, CONNECTION_START_TIME, LOCK_TIMEOUT_VAL, NUM_LOCKS_WAITING, UOW_START_TIME, UOW_STOP_TIME, PREV_UOW_STOP_TIME, NUM_ASSOC_AGENTS, ASSOCIATED_AGENTS_TOP, SORT_HEAP_ALLOCATED, SORT_SHRHEAP_ALLOCATED",
         "quickparse_summary_columns": "APPLICATION_HANDLE, MEMBER, CONNECTION_START_TIME, AGENT_WAIT_TIME, AGENT_WAITS_TOTAL, LOCK_TIMEOUTS, LOCK_WAIT_TIME, LOG_BUFFER_WAIT_TIME, NUM_LOG_BUFFER_FULL, LOG_DISK_WAIT_TIME, ROWS_READ, TOTAL_ACT_TIME, TOTAL_CPU_TIME, TOTAL_WAIT_TIME, TOTAL_ACT_WAIT_TIME"

--- a/1_setup/task_details.json
+++ b/1_setup/task_details.json
@@ -1,5 +1,27 @@
 [
     {
+        "field_name": "AV_PREFETCH_WAIT_TIME",
+        "field_valid": "true",
+        "field_type": "decimal(5,2)",
+        "field_formula": "CASE WHEN PREFETCH_WAITS = 0 THEN 0 ELSE ( PREFETCH_WAIT_TIME / PREFETCH_WAIT_TIME ) end"
+    },
+    {
+        "field_name": "ACTIVE_LOG_RANGE",
+        "field_valid": "false"
+    },
+    {
+        "field_name": "TOTAL_POOL_L_READS",
+        "field_valid": "true",
+        "field_type": "bigint",
+        "field_formula": "POOL_DATA_L_READS + POOL_INDEX_L_READS + POOL_TEMP_DATA_L_READS + POOL_TEMP_INDEX_L_READS + POOL_TEMP_XDA_L_READS + POOL_XDA_L_READS"
+    },
+    {
+        "field_name": "TOTAL_POOL_P_READS",
+        "field_valid": "true",
+        "field_type": "bigint",
+        "field_formula": "POOL_DATA_P_READS + POOL_INDEX_P_READS + POOL_TEMP_DATA_P_READS + POOL_TEMP_INDEX_P_READS + POOL_TEMP_XDA_P_READS + POOL_XDA_P_READS"
+    },
+    {
         "collection_name": "ENV_GET_SYSTEM_RESOURCES",
         "collection_class": "SQL",
         "collection_command": "SELECT CURRENT TIMESTAMP AS COLLECTION_TIME, T.* FROM TABLE ( SYSPROC.ENV_GET_SYSTEM_RESOURCES ( ) ) T",
@@ -39,6 +61,7 @@
         "collection_freq": "*/3 * * * *",
         "collection_level": "1",
         "collection_condition": "",
+	"loader_additional_fields": "AV_PREFETCH_WAIT_TIME, TOTAL_POOL_L_READS, TOTAL_POOL_P_READS",
         "loader_join_columns": "APPLICATION_HANDLE, MEMBER",
         "loader_diff_exempt_columns": "APPLICATION_HANDLE, CLIENT_PID, CONNECTION_START_TIME, LOCK_TIMEOUT_VAL, NUM_LOCKS_WAITING, UOW_START_TIME, UOW_STOP_TIME, PREV_UOW_STOP_TIME, NUM_ASSOC_AGENTS, ASSOCIATED_AGENTS_TOP, SORT_HEAP_ALLOCATED, SORT_SHRHEAP_ALLOCATED",
         "quickparse_summary_columns": "APPLICATION_HANDLE, MEMBER, CONNECTION_START_TIME, AGENT_WAIT_TIME, AGENT_WAITS_TOTAL, LOCK_TIMEOUTS, LOCK_WAIT_TIME, LOG_BUFFER_WAIT_TIME, NUM_LOG_BUFFER_FULL, LOG_DISK_WAIT_TIME, ROWS_READ, TOTAL_ACT_TIME, TOTAL_CPU_TIME, TOTAL_WAIT_TIME, TOTAL_ACT_WAIT_TIME"
@@ -380,6 +403,7 @@
         "collection_freq": "*/10 * * * *",
         "collection_level": "2",
         "collection_condition": "",
+	"loader_additional_fields": "AV_PREFETCH_WAIT_TIME, TOTAL_POOL_L_READS, TOTAL_POOL_P_READS",
         "loader_join_columns": "MEMBER",
         "loader_diff_exempt_columns": "MEMBER, DB_CONN_TIME",
         "quickparse_summary_columns": ""


### PR DESCRIPTION
I added the option to create additional fields in the DELTA table (calculated from the raw collection data. Additional fields are configured in the `task_details.json` file e.g. 

```
    {
        "field_name": "@AV_PREFETCH_WAIT_TIME",
        "field_valid": "true",
        "field_type": "decimal(5,2)",
        "field_formula": "CASE WHEN PREFETCH_WAITS = 0 THEN 0 ELSE ( PREFETCH_WAIT_TIME / PREFETCH_WAIT_TIME ) end"
    },
    {
        "field_name": "@ACTIVE_LOG_RANGE",
        "field_valid": "false"
    },
    {
        "field_name": "@TOTAL_POOL_L_READS",
        "field_valid": "true",
        "field_type": "bigint",
        "field_formula": "POOL_DATA_L_READS + POOL_INDEX_L_READS + POOL_TEMP_DATA_L_READS + POOL_TEMP_INDEX_L_READS + POOL_TEMP_XDA_L_READS + POOL_XDA_L_READS"
    },
    {
        "field_name": "@TOTAL_POOL_P_READS",
        "field_valid": "true",
        "field_type": "bigint",
        "field_formula": "POOL_DATA_P_READS + POOL_INDEX_P_READS + POOL_TEMP_DATA_P_READS + POOL_TEMP_INDEX_P_READS + POOL_TEMP_XDA_P_READS + POOL_XDA_P_READS"
    }
```
In the data collection config, the additional fields can be used with a line
`"loader_additional_fields": "AV_PREFETCH_WAIT_TIME, TOTAL_POOL_L_READS, TOTAL_POOL_P_READS",`
The fields can be marked as invalid. Invalid, or non-existing specification in the collection config are reported as a warning, and are ignored.
The additional fields are appended to the DELTA table via ALTER TABLE .